### PR TITLE
fix: Adding connected emitter on WS connection

### DIFF
--- a/src/ButtplugPanel/ButtplugPanel.ts
+++ b/src/ButtplugPanel/ButtplugPanel.ts
@@ -65,6 +65,7 @@ export class ButtplugPanelType extends Vue {
       this.InitializeClient(buttplugClient);
       await buttplugClient.ConnectWebsocket(aConnectObj.address);
       this.buttplugClient = buttplugClient;
+      this.$emit("connected");
     } catch (e) {
       // If we get an error thrown while trying to connect, we won't get much
       // information on why due to browser security contraints. Just explain


### PR DESCRIPTION
Fixes #15 by emitting connected once the ButtplugClient holder object
is set to the conenctted client object.